### PR TITLE
Add backend-editable content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+npm-debug.log*
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Guarding Panda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# guardingpanda
+# Guarding Panda
+
+这是一个简单的企业官网示例项目，使用 Node.js 和 Express 搭建。网站内容存放在 `data/content.json` 中，可通过后台页面在线修改。
+
+## 环境要求
+- Node.js 18 或更高版本
+- npm
+
+## 安装与运行
+```bash
+npm install      # 安装依赖
+npm start        # 启动服务器，默认端口 3000
+```
+
+启动后在浏览器访问 `http://localhost:3000` 即可看到首页，如需修改展示内容，可访问 `http://localhost:3000/admin` 进行编辑。
+
+## 许可证
+本项目使用 MIT License，详情见 [LICENSE](LICENSE)。

--- a/data/content.json
+++ b/data/content.json
@@ -1,0 +1,5 @@
+{
+  "title": "Guarding Panda",
+  "welcome": "欢迎来到 Guarding Panda",
+  "message": "这是企业官网示例首页。"
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const DATA_PATH = path.join(__dirname, 'data', 'content.json');
+
+app.use(express.urlencoded({ extended: true }));
+app.use('/static', express.static('public'));
+
+function loadContent() {
+  const raw = fs.readFileSync(DATA_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+function saveContent(data) {
+  fs.writeFileSync(DATA_PATH, JSON.stringify(data, null, 2));
+}
+
+function render(template, data) {
+  let html = fs.readFileSync(path.join(__dirname, 'views', template), 'utf8');
+  for (const [key, value] of Object.entries(data)) {
+    const regex = new RegExp(`{{\s*${key}\s*}}`, 'g');
+    html = html.replace(regex, value);
+  }
+  return html;
+}
+
+app.get('/', (req, res) => {
+  const content = loadContent();
+  res.send(render('index.html', content));
+});
+
+app.get('/admin', (req, res) => {
+  const content = loadContent();
+  res.send(render('admin.html', content));
+});
+
+app.post('/admin', (req, res) => {
+  const { title, welcome, message } = req.body;
+  saveContent({ title, welcome, message });
+  res.redirect('/');
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "guardingpanda",
+  "version": "1.0.0",
+  "description": "\u4f01\u4e1a\u5b98\u7f51\u793a\u4f8b",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"No tests specified\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/views/admin.html
+++ b/views/admin.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <title>后台管理</title>
+</head>
+<body>
+    <h1>更新网站内容</h1>
+    <form action="/admin" method="post">
+        <label>标题: <input type="text" name="title" value="{{title}}" /></label><br/>
+        <label>欢迎语: <input type="text" name="welcome" value="{{welcome}}" /></label><br/>
+        <label>信息:<br/>
+            <textarea name="message" rows="4" cols="50">{{message}}</textarea>
+        </label><br/>
+        <button type="submit">保存</button>
+    </form>
+</body>
+</html>

--- a/views/index.html
+++ b/views/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <title>{{title}}</title>
+</head>
+<body>
+    <h1>{{welcome}}</h1>
+    <p>{{message}}</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a small template system with editable content
- provide admin page to change website text
- update README with instructions in Chinese

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fa33375448321b241b442ea050489